### PR TITLE
Update resolve_download.py to include "street" field [#19]

### DIFF
--- a/python/resolve_download.py
+++ b/python/resolve_download.py
@@ -58,6 +58,7 @@ def download_using_id(download_id: str, refer_id: str = "77ef91f67a9e411bbbe299e
         "country": "us",
         "state": "New York",
         "city": "FPK",
+        "street": "Bowery 146",
         "product": "DaVinci Resolve"
     }
 


### PR DESCRIPTION
This changes the "python/resolve_download.py" file so that the "street" field is included into the download request.

Closes  issue #19 .