### PR TITLE
Document dependency fetching for build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By default, com.blackmagic.Resolve.yaml is configured to package the latest vers
 
 #### Free
 ```
-flatpak-builder --force-clean --repo=repo build-dir com.blackmagic.Resolve.yaml
+flatpak-builder --install-deps-from=flathub --force-clean --repo=repo build-dir com.blackmagic.Resolve.yaml
 flatpak build-bundle repo resolve.flatpak com.blackmagic.Resolve
 ```
 #### Studio


### PR DESCRIPTION
The build worked great for me, thanks! However, this parameter was necessary to pull the SDK. Otherwise, the following error occurred:
```
error: org.freedesktop.Sdk/x86_64/22.08 not installed
Failed to init: Unable to find sdk org.freedesktop.Sdk version 22.08
```