### PR TITLE
Add dGPU preference to desktop file to help on systems with hybrid graphics.

### DIFF
--- a/com.blackmagic.Resolve.desktop
+++ b/com.blackmagic.Resolve.desktop
@@ -3,3 +3,4 @@ Type=Application
 Name=Davinci Resolve
 Icon=com.blackmagic.Resolve
 Exec=/app/bin/resolve.sh
+PrefersNonDefaultGPU=true

--- a/com.blackmagic.ResolveStudio.desktop
+++ b/com.blackmagic.ResolveStudio.desktop
@@ -3,3 +3,4 @@ Type=Application
 Name=Davinci Resolve Studio
 Icon=com.blackmagic.ResolveStudio
 Exec=/app/bin/resolve.sh
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
Tell the app to launch on the dGPU (in systems with hybrid graphics).

As per freedesktop spec:
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys