### PR TITLE
Fix missing libcrypt by dropping freedesktop sdk version down

### DIFF
--- a/com.blackmagic.Resolve.yaml
+++ b/com.blackmagic.Resolve.yaml
@@ -4,7 +4,7 @@
 ####
 app-id: com.blackmagic.Resolve
 runtime: org.freedesktop.Platform
-runtime-version: &runtime-version '23.08'
+runtime-version: &runtime-version '22.08'
 sdk: org.freedesktop.Sdk
 finish-args:
   - --share=ipc

--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -4,7 +4,7 @@
 ####
 app-id: com.blackmagic.ResolveStudio
 runtime: org.freedesktop.Platform
-runtime-version: &runtime-version '23.08'
+runtime-version: &runtime-version '22.08'
 sdk: org.freedesktop.Sdk
 finish-args:
   - --share=ipc


### PR DESCRIPTION
Current main branch is broken as Resolve will fail to launch due to reliance on a legacy version of libcrypt which is no longer packaged by default in the latest version of the freedesktop sdk.

See https://github.com/pobthebuilder/resolve-flatpak/issues/27 for more info.