### PR TITLE
Fix compatibility with new Freedesktop runtime (23.08)

### DIFF
--- a/com.blackmagic.Resolve.yaml
+++ b/com.blackmagic.Resolve.yaml
@@ -18,10 +18,45 @@ finish-args:
   - --filesystem=xdg-data
   - --filesystem=xdg-videos
   - --filesystem=~/.local/share/DaVinciResolve
+  - --filesystem=~/Desktop
+  - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 
 command: /app/bin/resolve.sh
 modules:
   - shared-modules/glu/glu-9.json
+  #Ship libcrypt.so.1 with flatpak as not provided by runtime or by Blackmagic. See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1708
+  - name: libxcrypt
+    buildsystem: autotools
+    config-opts: ["--enable-obsolete-api=glibc"]
+    sources:
+      - type: git
+        url: https://github.com/besser82/libxcrypt.git
+        tag: v4.4.36
+  - name: onetbb
+    disabled: true
+    buildsystem: cmake-ninja
+    config-opts:
+      - -Wno-dev
+      - -DTBB_TEST=OFF
+    sources:
+      - type: git
+        url: https://github.com/oneapi-src/oneTBB
+        tag: v2021.11.0
+  #Build libcxx and ship as a library with Resolve as BM is outdated and segfaults on some setups. Disabled by default.
+  - name: libcxx
+    disabled: true
+    buildsystem: cmake-ninja
+    builddir: true
+    subdir: runtimes
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi
+      - -DLLVM_TARGETS_TO_BUILD=X86
+      - -Wno-dev
+    sources:
+      - type: git
+        url: https://github.com/llvm/llvm-project.git
+        tag: llvmorg-17.0.6
   - name: resolve
     buildsystem: simple
     build-options:

--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -18,10 +18,45 @@ finish-args:
   - --filesystem=xdg-data
   - --filesystem=xdg-videos
   - --filesystem=~/.local/share/DaVinciResolve
+  - --filesystem=~/Desktop
+  - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 
 command: /app/bin/resolve.sh
 modules:
   - shared-modules/glu/glu-9.json
+  #Ship libcrypt.so.1 with flatpak as not provided by runtime or by Blackmagic. See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1708
+  - name: libxcrypt
+    buildsystem: autotools
+    config-opts: ["--enable-obsolete-api=glibc"]
+    sources:
+      - type: git
+        url: https://github.com/besser82/libxcrypt.git
+        tag: v4.4.36
+  - name: onetbb
+    disabled: true
+    buildsystem: cmake-ninja
+    config-opts:
+      - -Wno-dev
+      - -DTBB_TEST=OFF
+    sources:
+      - type: git
+        url: https://github.com/oneapi-src/oneTBB
+        tag: v2021.11.0
+  #Build libcxx and ship as a library with Resolve as BM is outdated and segfaults on some setups. Disabled by default.
+  - name: libcxx
+    disabled: true
+    buildsystem: cmake-ninja
+    builddir: true
+    subdir: runtimes
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi
+      - -DLLVM_TARGETS_TO_BUILD=X86
+      - -Wno-dev
+    sources:
+      - type: git
+        url: https://github.com/llvm/llvm-project.git
+        tag: llvmorg-17.0.6
   - name: resolve
     buildsystem: simple
     build-options:


### PR DESCRIPTION
Currently, resolve doesn't run when using the configuration from the master branch, due to a missing libcrypt.so.1 (which is normally provided by libxcrypt, but in modern versions it no longer provides the requisite library unless compiled with an additional flag).

This also sets Resolve to use the glibc-2.0 libraries provided by the flatpak runtime, instead of the older versions packaged into Resolve itself, which causes issues.

Using this configuration, Resolve now works perfectly with the freedesktop runtime 23.08

Fixes #27 .