### PR TITLE
Allow Resolve Studio to access USB devices (read USB licence key)

### DIFF
--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -12,7 +12,6 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
-  - --device=dri
   - --device=all
   - --filesystem=xdg-documents
   - --filesystem=xdg-cache

--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --device=dri
+  - --device=all
   - --filesystem=xdg-documents
   - --filesystem=xdg-cache
   - --filesystem=xdg-data


### PR DESCRIPTION
Current main branch does not allow Resolve Studio to see USB licence keys.

Allow access to all devices due to current limitations of flatpak not allowing access to USB devices specifically (see https://github.com/flatpak/xdg-desktop-portal/pull/1238 )