### PR TITLE
Add OOTB support for RustICL

### DIFF
--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -18,6 +18,8 @@ finish-args:
   - --filesystem=xdg-data
   - --filesystem=xdg-videos
   - --filesystem=~/.local/share/DaVinciResolve
+  - --env=RUSTICL_ENABLE=radeonsi,iris,nouveau
+  - --env=OCL_ICD_VENDORS=/usr/lib/x86_64-linux-gnu/GL/default/OpenCL/vendors/rusticl.icd
 
 command: /app/bin/resolve.sh
 modules:


### PR DESCRIPTION
Since RustICL is capable of running Davinci and is hardware agnostic, we should probably enable support OOTB.

Running OpenCL implementations from other vendors (e.g. Nvidia proprietary or AMD ROCm runtimes) requires the removal of OCL_ICD_VENDORS env param (easily done with Flatseal)