### PR TITLE
Add support for USB license keys

### DIFF
--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -13,6 +13,8 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --device=dri
+  - --device=usb
+  - --usb=vnd:096e
   - --filesystem=xdg-documents
   - --filesystem=xdg-cache
   - --filesystem=xdg-data


### PR DESCRIPTION
As of Flatpak version 1.16.0, `--device=usb` is now available. See https://docs.flatpak.org/en/latest/sandbox-permissions.html#usb-portal

Add support for accessing USB license keys to the flatpak env by adding the USB portal.

USB device vendor defined to attempt to avoid USB-related crashes Resolve is known to have.