### PR TITLE
Rearrange filesystem permissions

### DIFF
--- a/com.blackmagic.Resolve.yaml
+++ b/com.blackmagic.Resolve.yaml
@@ -11,14 +11,20 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=x11
-  - --socket=wayland
   - --device=dri
+  - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
-  - --filesystem=xdg-cache
-  - --filesystem=xdg-data
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-public-share
   - --filesystem=xdg-videos
-  - --filesystem=~/.local/share/DaVinciResolve
-  - --filesystem=~/Desktop
+  - --filesystem=/media
+  - --filesystem=/run/media
+  - --filesystem=/mnt
+  - --persist=.local/share/DaVinciResolve
+  - --persist=Videos/CacheClip
+  - --persist=Documents/BlackmagicDesign
   - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 
 command: /app/bin/resolve.sh

--- a/com.blackmagic.Resolve.yaml
+++ b/com.blackmagic.Resolve.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --filesystem=/mnt
   - --persist=.local/share/DaVinciResolve
   - --persist=Videos/CacheClip
+  - --persist=Videos/.gallery
   - --persist=Documents/BlackmagicDesign
   - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 

--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -11,14 +11,20 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=x11
-  - --socket=wayland
   - --device=dri
+  - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
-  - --filesystem=xdg-cache
-  - --filesystem=xdg-data
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-public-share
   - --filesystem=xdg-videos
-  - --filesystem=~/.local/share/DaVinciResolve
-  - --filesystem=~/Desktop
+  - --filesystem=/media
+  - --filesystem=/run/media
+  - --filesystem=/mnt
+  - --persist=.local/share/DaVinciResolve
+  - --persist=Videos/CacheClip
+  - --persist=Documents/BlackmagicDesign
   # https://www.reddit.com/r/Fedora/comments/12z32r1/davinci_resolve_libpango_undefined_symbol_g/
   # - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0
 

--- a/com.blackmagic.ResolveStudio.yaml
+++ b/com.blackmagic.ResolveStudio.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --filesystem=/mnt
   - --persist=.local/share/DaVinciResolve
   - --persist=Videos/CacheClip
+  - --persist=Videos/.gallery
   - --persist=Documents/BlackmagicDesign
   # https://www.reddit.com/r/Fedora/comments/12z32r1/davinci_resolve_libpango_undefined_symbol_g/
   # - --env=LD_PRELOAD=/lib/x86_64-linux-gnu/libglib-2.0.so.0 /lib/x86_64-linux-gnu/libgio-2.0.so.0 /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 /lib/x86_64-linux-gnu/libgobject-2.0.so.0


### PR DESCRIPTION
This will add the ability to access media from external drives, and comply with Flathub's requirement of avoiding sharing data with a non-Flatpak installation. This also ensures that wiping the app via Flatpak will not leave leftover data on the home folder.